### PR TITLE
feat(AlertDialog): support secondary button

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -12,10 +12,21 @@ interface Props {
     label: string;
     buttonAction?: () => void;
   };
+  secondaryButton?: {
+    label: string;
+    buttonAction?: () => void;
+  };
 }
 
 const AlertDialog = (props: Props): React.JSX.Element => {
-  const { title, text, button, children = null, onClose } = props;
+  const {
+    title,
+    text,
+    button,
+    children = null,
+    onClose,
+    secondaryButton,
+  } = props;
 
   return (
     <div
@@ -53,7 +64,19 @@ const AlertDialog = (props: Props): React.JSX.Element => {
             </div>
             {children && <div>{children}</div>}
             {button && (
-              <div className="flex justify-end pt-[32px]">
+              <div
+                className="flex justify-end pt-[32px] gap-3 items-center"
+                // FIXME: Using inline style because gap-3 is not working
+                style={{ gap: "12px" }}
+              >
+                {secondaryButton && (
+                  <Button
+                    variant="secondary"
+                    onClick={secondaryButton?.buttonAction}
+                  >
+                    {secondaryButton.label}
+                  </Button>
+                )}
                 <Button variant="primary" onClick={button?.buttonAction}>
                   {button?.label}
                 </Button>

--- a/src/stories/AlertDialog.stories.tsx
+++ b/src/stories/AlertDialog.stories.tsx
@@ -18,11 +18,15 @@ function AlertDialogDemo() {
       text="Some text to display when modal is open"
       button={{
         label: "Redirect",
-        buttonAction: () => console.log('button click')
+        buttonAction: () => console.log("button click"),
       }}
       children={<div className="py-4">SOME CHILD CONTENT</div>}
-    > 
-      </AlertDialog>
+      onClose={() => console.log("closed")}
+      secondaryButton={{
+        label: "Cancel",
+        buttonAction: () => console.log("secondary click"),
+      }}
+    ></AlertDialog>
   );
 }
 


### PR DESCRIPTION
![image](https://github.com/awell-health/design-system/assets/19916684/84f90731-0a10-403c-ab72-c89e140ad804)
Secondary button required for duplicate care flow support

@skrobek FYI there is a `FIXME` in this MR related to gap not working with tailwind (though works fine with inline style). Merging this PR so I can continue with the feature, but we're going to have to revisit the inline style in the alert dialog button actions.