### PR TITLE
Rev 454 fix badge rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.12.99",
+  "version": "0.13.0",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/ui/badge/__snapshots__/badge.spec.tsx.snap
+++ b/src/components/ui/badge/__snapshots__/badge.spec.tsx.snap
@@ -3,7 +3,11 @@
 exports[`Badge > match snapshot 1`] = `
 <div>
   <div
-    class="badge rounded-2xl bg-slate-100 text-slate-800 border-slate-100 badge-sm p-2"
-  />
+    class="badge rounded-2xl inline-flex items-center justify-center overflow-hidden max-w-full min-w-0 bg-slate-100 text-slate-800 border-slate-100 badge-sm p-2 text-xs"
+  >
+    <span
+      class="truncate px-1"
+    />
+  </div>
 </div>
 `;

--- a/src/components/ui/badge/badge.tsx
+++ b/src/components/ui/badge/badge.tsx
@@ -3,38 +3,45 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
-const badgeVariants = cva('badge rounded-2xl', {
-  variants: {
-    variant: {
-      default: 'bg-slate-100 text-slate-800 border-slate-100',
-      primary: 'bg-blue-100 text-blue-800 border-blue-100',
-      error: 'bg-red-100 text-red-800 border-red-100',
-      warning: 'bg-orange-100 text-orange-800 border-orange-100',
-      success: 'bg-green-100 text-green-800 border-green-100',
-      yellow: 'bg-yellow-100 text-yellow-800 border-yellow-100',
-      lime: 'bg-lime-100 text-lime-800 border-lime-100',
-      cyan: 'bg-cyan-100 text-cyan-800 border-cyan-100',
-      teal: 'bg-teal-100 text-teal-800 border-teal-100',
-      violet: 'bg-violet-100 text-violet-800 border-violet-100',
-      pink: 'bg-pink-100 text-pink-800 border-pink-100'
+const badgeVariants = cva(
+  'badge rounded-2xl inline-flex items-center justify-center overflow-hidden max-w-full min-w-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-slate-100 text-slate-800 border-slate-100',
+        primary: 'bg-blue-100 text-blue-800 border-blue-100',
+        error: 'bg-red-100 text-red-800 border-red-100',
+        warning: 'bg-orange-100 text-orange-800 border-orange-100',
+        success: 'bg-green-100 text-green-800 border-green-100',
+        yellow: 'bg-yellow-100 text-yellow-800 border-yellow-100',
+        lime: 'bg-lime-100 text-lime-800 border-lime-100',
+        cyan: 'bg-cyan-100 text-cyan-800 border-cyan-100',
+        teal: 'bg-teal-100 text-teal-800 border-teal-100',
+        violet: 'bg-violet-100 text-violet-800 border-violet-100',
+        pink: 'bg-pink-100 text-pink-800 border-pink-100'
+      },
+      size: {
+        sm: 'badge-sm p-2 text-xs',
+        lg: 'badge-lg p-3 text-sm'
+      }
     },
-    size: {
-      sm: 'badge-sm p-2',
-      lg: 'badge-lg p-3'
+    defaultVariants: {
+      variant: 'default',
+      size: 'sm'
     }
-  },
-  defaultVariants: {
-    variant: 'default',
-    size: 'sm'
   }
-});
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, size, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant, size }), className)} {...props} />;
+function Badge({ className, variant, size, children, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant, size }), className)} {...props}>
+      <span className='truncate px-1'>{children}</span>
+    </div>
+  );
 }
 
 export { Badge, badgeVariants };

--- a/src/stories/Badge.stories.tsx
+++ b/src/stories/Badge.stories.tsx
@@ -2,7 +2,36 @@ import { Badge } from '@/components/ui/badge/badge';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
-  component: Badge
+  component: Badge,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: [
+        'default',
+        'primary',
+        'error',
+        'warning',
+        'success',
+        'yellow',
+        'lime',
+        'cyan',
+        'teal',
+        'violet',
+        'pink'
+      ]
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'lg']
+    },
+    children: {
+      control: { type: 'text' }
+    }
+  }
 } satisfies Meta<typeof Badge>;
 
 export default meta;
@@ -16,4 +45,111 @@ export const Example = {
     children: 'Label'
   },
   render: (args) => <Badge {...args} />
+} satisfies Story;
+
+export const AllVariants = {
+  render: () => (
+    <div className='flex flex-wrap gap-2'>
+      <Badge variant='default'>Default</Badge>
+      <Badge variant='primary'>Primary</Badge>
+      <Badge variant='error'>Error</Badge>
+      <Badge variant='warning'>Warning</Badge>
+      <Badge variant='success'>Success</Badge>
+      <Badge variant='yellow'>Yellow</Badge>
+      <Badge variant='lime'>Lime</Badge>
+      <Badge variant='cyan'>Cyan</Badge>
+      <Badge variant='teal'>Teal</Badge>
+      <Badge variant='violet'>Violet</Badge>
+      <Badge variant='pink'>Pink</Badge>
+    </div>
+  )
+} satisfies Story;
+
+export const Sizes = {
+  render: () => (
+    <div className='flex items-center gap-4'>
+      <Badge size='sm'>Small Badge</Badge>
+      <Badge size='lg'>Large Badge</Badge>
+    </div>
+  )
+} satisfies Story;
+
+export const TextOverflow = {
+  name: 'Text Overflow Handling',
+  render: () => (
+    <div className='space-y-6 max-w-2xl'>
+      <div>
+        <h3 className='text-sm font-medium mb-2'>
+          Natural growth - badges grow with content when space allows
+        </h3>
+        <div className='flex flex-wrap gap-2'>
+          <Badge size='sm' variant='primary'>
+            Short
+          </Badge>
+          <Badge size='sm' variant='error'>
+            Medium length text
+          </Badge>
+          <Badge size='sm' variant='success'>
+            This is a longer badge text that grows naturally
+          </Badge>
+          <Badge size='lg' variant='warning'>
+            Large badge with even longer text content that spans naturally
+          </Badge>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='text-sm font-medium mb-2'>
+          Constrained space - text truncates gracefully with ellipsis
+        </h3>
+        <div className='grid grid-cols-2 gap-4'>
+          <div className='w-32 border border-gray-200 p-2 rounded bg-gray-50'>
+            <p className='text-xs text-gray-600 mb-1'>Width: 8rem</p>
+            <Badge variant='primary' size='sm'>
+              This badge text is too long for this container
+            </Badge>
+          </div>
+          <div className='w-24 border border-gray-200 p-2 rounded bg-gray-50'>
+            <p className='text-xs text-gray-600 mb-1'>Width: 6rem</p>
+            <Badge variant='error' size='sm'>
+              Super long badge text
+            </Badge>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='text-sm font-medium mb-2'>
+          Flex containers - badges adapt to available space
+        </h3>
+        <div className='flex gap-2 w-96 border border-gray-200 p-2 rounded bg-gray-50'>
+          <Badge variant='cyan' size='sm'>
+            Status
+          </Badge>
+          <Badge variant='yellow' size='sm'>
+            This badge will take available space and truncate if needed
+          </Badge>
+          <Badge variant='violet' size='sm'>
+            End
+          </Badge>
+        </div>
+      </div>
+
+      <div>
+        <h3 className='text-sm font-medium mb-2'>Mixed sizes handling overflow</h3>
+        <div className='w-64 border border-gray-200 p-2 rounded bg-gray-50 space-y-2'>
+          <div>
+            <Badge size='sm' variant='primary'>
+              Small badge with very long text that demonstrates truncation
+            </Badge>
+          </div>
+          <div>
+            <Badge size='lg' variant='success'>
+              Large badge with very long text that also demonstrates truncation behavior
+            </Badge>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 } satisfies Story;

--- a/style.css
+++ b/style.css
@@ -1251,6 +1251,12 @@ html{
     --tw-bg-opacity: 1;
     background-color: var(--fallback-b2,oklch(var(--b2)/var(--tw-bg-opacity)));
   }
+
+  .table-zebra tr.hover:hover,
+  .table-zebra tr.hover:nth-child(even):hover{
+    --tw-bg-opacity: 1;
+    background-color: var(--fallback-b3,oklch(var(--b3)/var(--tw-bg-opacity)));
+  }
 }
 
 .btn{
@@ -4378,6 +4384,10 @@ input.tab:checked + .tab-content,
   margin-top: 100px;
 }
 
+.mb-4{
+  margin-bottom: 1rem;
+}
+
 .box-border{
   box-sizing: border-box;
 }
@@ -4586,6 +4596,10 @@ input.tab:checked + .tab-content,
   width: 2.25rem;
 }
 
+.w-96{
+  width: 24rem;
+}
+
 .w-\[1024px\]{
   width: 1024px;
 }
@@ -4622,12 +4636,20 @@ input.tab:checked + .tab-content,
   width: 100vw;
 }
 
+.w-48{
+  width: 12rem;
+}
+
 .min-w-8{
   min-width: 2rem;
 }
 
 .min-w-\[46px\]{
   min-width: 46px;
+}
+
+.min-w-0{
+  min-width: 0px;
 }
 
 .max-w-2xl{
@@ -4652,6 +4674,14 @@ input.tab:checked + .tab-content,
 
 .max-w-xs{
   max-width: 20rem;
+}
+
+.max-w-lg{
+  max-width: 32rem;
+}
+
+.max-w-32{
+  max-width: 8rem;
 }
 
 .flex-1{
@@ -4708,6 +4738,10 @@ input.tab:checked + .tab-content,
 
 .cursor-pointer{
   cursor: pointer;
+}
+
+.resize{
+  resize: both;
 }
 
 .list-decimal{
@@ -4800,10 +4834,22 @@ input.tab:checked + .tab-content,
   gap: 2rem;
 }
 
+.space-y-2 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
+}
+
 .space-y-3 > :not([hidden]) ~ :not([hidden]){
   --tw-space-y-reverse: 0;
   margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
 }
 
 .self-start{
@@ -4820,6 +4866,12 @@ input.tab:checked + .tab-content,
 
 .overflow-y-auto{
   overflow-y: auto;
+}
+
+.truncate{
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .whitespace-normal{
@@ -5024,6 +5076,11 @@ input.tab:checked + .tab-content,
   border-color: rgb(253 224 71 / var(--tw-border-opacity, 1));
 }
 
+.border-green-200{
+  --tw-border-opacity: 1;
+  border-color: rgb(187 247 208 / var(--tw-border-opacity, 1));
+}
+
 .\!bg-slate-100{
   --tw-bg-opacity: 1 !important;
   background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1)) !important;
@@ -5180,6 +5237,11 @@ input.tab:checked + .tab-content,
 .bg-yellow-50{
   --tw-bg-opacity: 1;
   background-color: rgb(254 252 232 / var(--tw-bg-opacity, 1));
+}
+
+.bg-green-50{
+  --tw-bg-opacity: 1;
+  background-color: rgb(240 253 244 / var(--tw-bg-opacity, 1));
 }
 
 .bg-opacity-30{
@@ -5836,6 +5898,10 @@ input.tab:checked + .tab-content,
 
 .ease-in-out{
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.running{
+  animation-play-state: running;
 }
 
 html {


### PR DESCRIPTION
### **User description**
<img width="99" height="84" alt="Screenshot 2025-08-01 at 09 53 42" src="https://github.com/user-attachments/assets/73ff449e-3ef9-477c-9f40-95fb67cca64b" />
<img width="685" height="430" alt="Screenshot 2025-08-01 at 10 12 18" src="https://github.com/user-attachments/assets/f2e1fbfc-6423-4c05-af32-37cb6248ebe1" />


___

### **PR Type**
Enhancement


___

### **Description**
- Enhance `Badge` styling and layout utilities

- Support `size` variants with default `sm` and `lg`

- Wrap content in truncate-enabled span element

- Add Storybook controls and comprehensive badge stories


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>badge.tsx</strong><dd><code>Enhance badge layout and truncation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ui/badge/badge.tsx

<ul><li>Extended badge base classes (inline-flex, overflow-hidden)<br> <li> Added <code>size</code> variants (<code>sm</code>, <code>lg</code>) with defaults<br> <li> Wrapped <code>children</code> in truncate-enabled <code><span></code></ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/design-system/pull/232/files#diff-38d8ed2a756ab009334b864185cf731f9e1c90bf564946939866ca4579067194">+31/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>style.css</strong><dd><code>Add CSS utilities for badge styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

style.css

<ul><li>Introduced utility classes (truncate, resize, space-y)<br> <li> Added margin, width, min/max-width classes<br> <li> Added table-zebra hover and color utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/design-system/pull/232/files#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7a">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Badge.stories.tsx</strong><dd><code>Add Storybook controls and badge stories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/stories/Badge.stories.tsx

<ul><li>Configured Storybook layout and autodocs tag<br> <li> Defined <code>variant</code>, <code>size</code>, <code>children</code> controls<br> <li> Added stories: AllVariants, Sizes, TextOverflow</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/design-system/pull/232/files#diff-bfbf94ecc8f06ab5bd8905d6402321ae7c0a2b2a733a5317e47e791a474682bc">+137/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump package version to 0.13.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bumped version from `0.12.99` to `0.13.0`


</details>


  </td>
  <td><a href="https://github.com/awell-health/design-system/pull/232/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

