### PR TITLE
Fix current year date range selection

### DIFF
--- a/src/components/ui/date-range-select/DateRangeSelect.tsx
+++ b/src/components/ui/date-range-select/DateRangeSelect.tsx
@@ -59,6 +59,10 @@ const DateRangeSelect: FC<Props> = (props) => {
   };
 
   const getDateFromPast = (days: number | null): Date => {
+    if (days === null) {
+      return new Date(new Date().getFullYear(), 0, 1);
+    }
+
     if (typeof days !== 'number') {
       return new Date();
     }

--- a/style.css
+++ b/style.css
@@ -5876,10 +5876,6 @@ input.tab:checked + .tab-content,
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.\[overflow-wrap\:anywhere\]{
-  overflow-wrap: anywhere;
-}
-
 html {
   font-family: "Inter", sans-serif;
   font-optical-sizing: auto;


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix current-year range when days is null

- Default start date to Jan 1 current year

- Remove unused CSS overflow-wrap utility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DateRangeSelect.getDateFromPast"] -- "days === null" --> B["Return Jan 1 of current year"]
  A -- "invalid days" --> C["Return new Date()"]
  D["style.css"] -- "remove unused rule" --> E["[overflow-wrap:anywhere] deleted"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DateRangeSelect.tsx</strong><dd><code>Handle null to start from current year</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ui/date-range-select/DateRangeSelect.tsx

<ul><li>Handle null days as Jan 1 current year.<br> <li> Preserve existing fallbacks for non-number inputs.</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/design-system/pull/239/files#diff-f5c66301bf96f97011b5afac245f5e73b8f1c8f266f8dd3bedb9f6f05ca748f4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>style.css</strong><dd><code>Remove unused overflow-wrap utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

style.css

<ul><li>Remove custom <code>[overflow-wrap:anywhere]</code> utility rule.<br> <li> Minor stylesheet cleanup.</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/design-system/pull/239/files#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7a">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

