### PR TITLE
feat: Next.js 15 App Router SSR compatibility (v0.16.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.15.7",
+  "version": "0.16.0",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/ui/action-icon/action-icon.tsx
+++ b/src/components/ui/action-icon/action-icon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { Icon, IconType } from '../icon';

--- a/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 

--- a/src/components/ui/alert/alert.tsx
+++ b/src/components/ui/alert/alert.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/avatar/avatar.tsx
+++ b/src/components/ui/avatar/avatar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/badge/badge.tsx
+++ b/src/components/ui/badge/badge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/button/button.tsx
+++ b/src/components/ui/button/button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/card/card.tsx
+++ b/src/components/ui/card/card.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/copy-text/copy-text.tsx
+++ b/src/components/ui/copy-text/copy-text.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC, useEffect, useState } from 'react';
 import { Icon, IconSize } from '../icon';
 import React from 'react';

--- a/src/components/ui/data-point-icon/data-point-icon.tsx
+++ b/src/components/ui/data-point-icon/data-point-icon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { Icon, IconType } from '../icon';

--- a/src/components/ui/date-range-select/DateRangeSelect.tsx
+++ b/src/components/ui/date-range-select/DateRangeSelect.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type FC, useEffect, useRef, useState } from 'react';
 import { useClickAway } from 'react-use';
 import {

--- a/src/components/ui/date-time-range-selector/DateInput.tsx
+++ b/src/components/ui/date-time-range-selector/DateInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import type { DateInputProps } from './types';

--- a/src/components/ui/date-time-range-selector/DateTimeInput.tsx
+++ b/src/components/ui/date-time-range-selector/DateTimeInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { DateInput } from './DateInput';

--- a/src/components/ui/date-time-range-selector/DateTimeRangeSelector.tsx
+++ b/src/components/ui/date-time-range-selector/DateTimeRangeSelector.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { useRef, useState, useCallback, useEffect } from 'react';
 import { useClickAway } from 'react-use';

--- a/src/components/ui/date-time-range-selector/TimeInput.tsx
+++ b/src/components/ui/date-time-range-selector/TimeInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { Icon } from '../icon';

--- a/src/components/ui/dialog/dialog.tsx
+++ b/src/components/ui/dialog/dialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/divider/Divider.tsx
+++ b/src/components/ui/divider/Divider.tsx
@@ -1,1 +1,3 @@
+'use client';
+
 export const Divider = (): JSX.Element => <div className='h-[1.5px] bg-gray-200 w-full' />;

--- a/src/components/ui/drawer/drawer.tsx
+++ b/src/components/ui/drawer/drawer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ReactNode, type FC } from 'react';
 import clsx from 'clsx';
 

--- a/src/components/ui/dropdown/dropdown.tsx
+++ b/src/components/ui/dropdown/dropdown.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 import { DropdownItem } from './types';

--- a/src/components/ui/file-list/file-list.tsx
+++ b/src/components/ui/file-list/file-list.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC } from 'react';
 import { Button } from '../button/button';
 import { Icon } from '../icon';

--- a/src/components/ui/file-upload/file-upload.tsx
+++ b/src/components/ui/file-upload/file-upload.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ChangeEvent, FC, useEffect, useRef, useState } from 'react';
 import { Button } from '../button/button';
 import { cn } from '../../../lib/utils';

--- a/src/components/ui/form/checkbox/checkbox.tsx
+++ b/src/components/ui/form/checkbox/checkbox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/form/form-buttons/form-buttons.tsx
+++ b/src/components/ui/form/form-buttons/form-buttons.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC } from 'react';
 import { cn } from '../../../../lib/utils';
 

--- a/src/components/ui/form/form-content/form-content.tsx
+++ b/src/components/ui/form/form-content/form-content.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '../../../../lib/utils';
 
 interface Props extends React.InputHTMLAttributes<HTMLDivElement> {

--- a/src/components/ui/form/form-section/FormSection.tsx
+++ b/src/components/ui/form/form-section/FormSection.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC } from 'react';
 import { cn } from '@/lib/utils';
 interface Props {

--- a/src/components/ui/form/input/input.tsx
+++ b/src/components/ui/form/input/input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/form/label/label.tsx
+++ b/src/components/ui/form/label/label.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FC, ReactNode } from 'react';
 import { cn } from '../../../../lib/utils';
 

--- a/src/components/ui/form/list-input/ListInput.tsx
+++ b/src/components/ui/form/list-input/ListInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 import { Icon } from '../../icon';
 import { cn } from '../../../../lib/utils';

--- a/src/components/ui/form/phone-input/country-selector.tsx
+++ b/src/components/ui/form/phone-input/country-selector.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   FlagImage,

--- a/src/components/ui/form/phone-input/phone-input.tsx
+++ b/src/components/ui/form/phone-input/phone-input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {
   defaultCountries,

--- a/src/components/ui/form/select/select.tsx
+++ b/src/components/ui/form/select/select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/lib/utils';
 import Select, { MultiValue, SingleValue, components } from 'react-select';
 import { GroupedOption, SelectItem, SelectValue } from './types';

--- a/src/components/ui/form/textarea/textarea.tsx
+++ b/src/components/ui/form/textarea/textarea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/form/toggle/toggle.tsx
+++ b/src/components/ui/form/toggle/toggle.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cn } from '../../../../lib/utils';
 

--- a/src/components/ui/icon/icon.tsx
+++ b/src/components/ui/icon/icon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { ICONS, IconSize, IconType } from './types';

--- a/src/components/ui/mdx-editor/mdx-editor.tsx
+++ b/src/components/ui/mdx-editor/mdx-editor.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type FC } from 'react';
 import {
   MDXEditor as BaseMDXEditor,

--- a/src/components/ui/menu/Menu.tsx
+++ b/src/components/ui/menu/Menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cloneElement } from 'react';
 import { cn } from '../../../lib/utils';
 import { MenuItem } from './types';

--- a/src/components/ui/modal/Modal.tsx
+++ b/src/components/ui/modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { ReactNode, type FC, type RefObject } from 'react';
 import { useClickAway, useKey } from 'react-use';
 import { cn } from '../../../lib/utils';

--- a/src/components/ui/pagination/pagination.tsx
+++ b/src/components/ui/pagination/pagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Fragment, useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Button } from '../button';

--- a/src/components/ui/radial-progress/radial-progress.tsx
+++ b/src/components/ui/radial-progress/radial-progress.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/rich-text/rich-text.tsx
+++ b/src/components/ui/rich-text/rich-text.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { FC } from 'react';
 import { cn } from '../../../lib/utils';

--- a/src/components/ui/sheet/sheet.tsx
+++ b/src/components/ui/sheet/sheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/skeleton-loader/skeleton-loader.tsx
+++ b/src/components/ui/skeleton-loader/skeleton-loader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/lib/utils';
 
 function SkeletonLoader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/src/components/ui/spinner/spinner.tsx
+++ b/src/components/ui/spinner/spinner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/tab/bordered-tab.tsx
+++ b/src/components/ui/tab/bordered-tab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/tab/tab.tsx
+++ b/src/components/ui/tab/tab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/table/table-cell.tsx
+++ b/src/components/ui/table/table-cell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/lib/utils';
 import * as React from 'react';
 

--- a/src/components/ui/table/table-header.tsx
+++ b/src/components/ui/table/table-header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/lib/utils';
 import * as React from 'react';
 import { Icon } from '../icon';

--- a/src/components/ui/table/table-row.tsx
+++ b/src/components/ui/table/table-row.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/lib/utils';
 import * as React from 'react';
 

--- a/src/components/ui/table/table.tsx
+++ b/src/components/ui/table/table.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/toast/toast.tsx
+++ b/src/components/ui/toast/toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/src/components/ui/tooltip/tooltip.tsx
+++ b/src/components/ui/tooltip/tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Tooltip as TooltipReact } from 'react-tooltip';

--- a/src/extended.ts
+++ b/src/extended.ts
@@ -1,3 +1,5 @@
+'use client';
+
 // Add the RichText component
 export { RichText, type RichTextProps } from './components/ui/rich-text';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
+'use client';
+
 export * from '@/components';

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     rollupOptions: {
       external: ['react', 'react-dom'],
       output: {
+        banner: "'use client';",
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM'


### PR DESCRIPTION
Add 'use client' directives to all 50 component files and both entry points (src/index.ts, src/extended.ts) so the design system works out-of-the-box in Next.js 13–15 App Router without consumers needing to wrap components in their own client boundaries.

Why 'use client' on every component:
- Next.js App Router treats all modules as server components by default
- Any component that uses hooks, event handlers, or browser APIs must be a client component
- Even purely presentational components (Button, Card, etc.) accept function props (onClick, onChange) that cannot cross the server-to-client boundary — marking them as client components prevents cryptic serialization errors for consumers
- Prior to Next.js 13 App Router, the Pages Router treated everything as client-side by default, so no directive was needed

Build change (vite.config.js):
- Added banner: "'use client';" to rollup output config so the directive is preserved as the first line of dist/index.es.js and dist/extended.es.js after bundling. Rollup strips directives from individual files during bundling without this; the banner ensures Next.js sees the boundary when it resolves the package entry point.

Compatibility:
- Next.js 14/15 App Router: fixed
- Next.js Pages Router: no change ('use client' is ignored)
- Non-Next.js (Vite, CRA, etc.): no change (directive is a no-op)