### PR TITLE
fix: externalize react/jsx-runtime and react/jsx-dev-runtime in rollu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "files": [
     "dist"

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
       fileName: (format, entryName) => `${entryName}.${format}.js`
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
       output: {
         banner: "'use client';",
         globals: {


### PR DESCRIPTION
…p config

With the automatic JSX transform (default since React 17, used by @vitejs/plugin-react), the compiler emits implicit imports from react/jsx-runtime (prod) and react/jsx-dev-runtime (dev) instead of React.createElement calls. These sub-path exports were not listed as external, so Vite was bundling React's JSX runtime into the library output rather than leaving it as a peer dependency.

Bundling the JSX runtime creates a second React instance in consumer apps alongside their own React installation. This breaks hooks (useState, useContext, etc.) and context propagation, and is particularly problematic in Next.js 15 App Router where SSR/RSC boundaries enforce strict React instance consistency.

Safe to externalize: peer dependencies already require ^18.3.1, which guarantees react/jsx-runtime is present in every consumer's node_modules.