### PR TITLE
feat(menu): support href/target on MenuItem for native link behavior (v0.16.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/ui/menu/Menu.tsx
+++ b/src/components/ui/menu/Menu.tsx
@@ -18,7 +18,9 @@ function Menu({ className, items, iconOnly = false, ...props }: Props) {
       active = false,
       className = '',
       onClick = undefined,
-      isExpanded = false
+      isExpanded = false,
+      href = undefined,
+      target = undefined
     } = item;
 
     const itemClassNames = cn(
@@ -50,7 +52,13 @@ function Menu({ className, items, iconOnly = false, ...props }: Props) {
     return (
       <li key={i}>
         {(!children || iconOnly) && (
-          <a className={itemClassNames} onClick={onClick}>
+          <a
+            className={itemClassNames}
+            href={href}
+            target={target}
+            rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+            onClick={onClick}
+          >
             {label}
           </a>
         )}

--- a/src/components/ui/menu/menu.spec.tsx
+++ b/src/components/ui/menu/menu.spec.tsx
@@ -49,6 +49,36 @@ describe('Menu', () => {
     expect(getByText('badge')).toBeVisible();
   });
 
+  it('renders a leaf item as a real link when href is set', () => {
+    const { getByText } = subject({
+      items: [{ label: 'Linked', href: '/somewhere' }]
+    });
+
+    const anchor = getByText('Linked').closest('a');
+    expect(anchor).toHaveAttribute('href', '/somewhere');
+    expect(anchor).not.toHaveAttribute('target');
+    expect(anchor).not.toHaveAttribute('rel');
+  });
+
+  it('adds target and rel for external/new-tab links', () => {
+    const { getByText } = subject({
+      items: [{ label: 'New tab', href: 'https://example.com', target: '_blank' }]
+    });
+
+    const anchor = getByText('New tab').closest('a');
+    expect(anchor).toHaveAttribute('href', 'https://example.com');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not set href on the anchor when omitted', () => {
+    const { getByText } = subject({
+      items: [{ label: 'Plain' }]
+    });
+
+    expect(getByText('Plain').closest('a')).not.toHaveAttribute('href');
+  });
+
   it('opens children menu', () => {
     const { getByText } = subject();
 

--- a/src/components/ui/menu/types.ts
+++ b/src/components/ui/menu/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { AnchorHTMLAttributes, ReactNode } from 'react';
 
 export interface MenuItem {
   label: string | JSX.Element | ReactNode;
@@ -9,4 +9,13 @@ export interface MenuItem {
   isExpanded?: boolean;
   className?: string;
   active?: boolean;
+  /**
+   * When set, the item renders as a real anchor with this `href`, enabling
+   * native browser behavior (right-click "Open in new tab", cmd/ctrl/middle
+   * click). `onClick` still fires for SPA navigation. Pass a plain string as
+   * `label` (not a nested `<a>`) to avoid invalid nested anchors.
+   */
+  href?: string;
+  /** Anchor target, e.g. `_blank`. Only applies when `href` is set. */
+  target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
 }


### PR DESCRIPTION
## Summary
- Adds optional `href` and `target` to `MenuItem`. Leaf/icon-only rows now render as a **real anchor** (`<a href target>`), with `rel="noopener noreferrer"` auto-applied for `target="_blank"`.
- This enables native browser behavior on menu items: right-click → "Open in new tab", cmd/ctrl/middle-click, etc. `onClick` still fires for SPA navigation.
- Lets consumers pass a plain string `label` instead of nesting an `<a>` inside the Menu's own anchor — nested anchors are invalid HTML and trigger hydration errors (e.g. in app-careops' `Sidebar`).
- Bumps version to **0.16.2** (stays on the React 18 / 0.16.x line; the React 19 / 1.0.0 work lives separately).

## Behavior
| MenuItem | Rendered anchor |
|---|---|
| no `href` | `<a onClick>` (unchanged from 0.16.1) |
| `href` set | `<a href onClick>` |
| `href` + `target="_blank"` | `<a href target="_blank" rel="noopener noreferrer" onClick>` |

The existing snapshot is unchanged (no `href` ⇒ no new attributes).

## Test plan
- [x] `yarn vitest run src/components/ui/menu/menu.spec.tsx` — 10 passing, incl. new href/target/rel assertions
- [x] `yarn build` (tsc + vite + tailwind) succeeds; `dist` emits the new anchor attrs and `MenuItem.href/target` types
- [ ] On merge, CI publishes `0.16.2` to npm; bump `@awell-health/design-system` to `0.16.2` in app-careops and switch the Sidebar to `href` + plain string `label`

Made with [Cursor](https://cursor.com)