### PR TITLE
feat(data-point-icon): add datetime value type with clock icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/ui/data-point-icon/__snapshots__/data-point-icon.spec.tsx.snap
+++ b/src/components/ui/data-point-icon/__snapshots__/data-point-icon.spec.tsx.snap
@@ -21,6 +21,27 @@ exports[`DataPointIcon > match snapshot 1`] = `
 </div>
 `;
 
+exports[`DataPointIcon > should render a clock icon for datetime 1`] = `
+<div>
+  <div
+    class="w-6 h-6 flex bg-slate-100 rounded-md border border-slate-200 items-center justify-center"
+  >
+    <svg
+      class="remixicon w-4 h-4 fill-slate-800"
+      fill="default"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM13 12H17V14H11V7H13V12Z"
+      />
+    </svg>
+  </div>
+</div>
+`;
+
 exports[`DataPointIcon > should render the correct icon 1`] = `
 <div>
   <div

--- a/src/components/ui/data-point-icon/data-point-icon.spec.tsx
+++ b/src/components/ui/data-point-icon/data-point-icon.spec.tsx
@@ -16,4 +16,10 @@ describe('DataPointIcon', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('should render a clock icon for datetime', () => {
+    const { container } = render(<DataPointIcon dataPointValueType='datetime' />);
+
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/ui/data-point-icon/data-point-icon.tsx
+++ b/src/components/ui/data-point-icon/data-point-icon.tsx
@@ -17,6 +17,7 @@ const DataPointIcon = React.forwardRef<HTMLDivElement, DataPointIconProps>(({ ..
     attachments_array: 'RiAttachment2',
     boolean: 'RiCheckboxCircleLine',
     date: 'RiCalendarLine',
+    datetime: 'RiTimeLine',
     json: 'RiBracesLine',
     number: 'RiHashtag',
     numbers_array: 'RiListOrdered2',

--- a/src/components/ui/data-point-icon/types.ts
+++ b/src/components/ui/data-point-icon/types.ts
@@ -3,6 +3,7 @@ export type DataPointValueType =
   | 'attachments_array'
   | 'boolean'
   | 'date'
+  | 'datetime'
   | 'json'
   | 'number'
   | 'numbers_array'


### PR DESCRIPTION
## What

`datetime` data points (e.g. `patient_profile:birth_date`) rendered the `RiQuestionFill` fallback because the value type was missing from `DataPointValueType` and `TYPES_ICONS_MAP`.

- Add `datetime` to the `DataPointValueType` union
- Map it to `RiTimeLine` (clock)
- Snapshot spec for the new mapping
- Bump to **0.16.3** — note this also publishes the pending MenuItem `href` change from #253 (main is at 0.16.2 which is already on npm, so that merge never released)

## Why

`@awell/data-points` `DataPointValueType` enum has `datetime` (profile `birth_date` is `DATETIME`), and careops studio/data-source views render `DataPointIcon` straight from it — every `datetime` field shows a "?" today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)