### PR TITLE
feat(file-upload): add capture attribute to the file input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/ui/file-upload/file-upload.spec.tsx
+++ b/src/components/ui/file-upload/file-upload.spec.tsx
@@ -28,4 +28,16 @@ describe('FileList Component', () => {
       throw new Error('Input not found');
     }
   });
+
+  it('sets the capture attribute on the input when provided', () => {
+    const { container } = subject({ capture: 'environment' });
+    const input = container.querySelector('input[type="file"]');
+    expect(input?.getAttribute('capture')).toBe('environment');
+  });
+
+  it('does not set the capture attribute by default', () => {
+    const { container } = subject();
+    const input = container.querySelector('input[type="file"]');
+    expect(input?.hasAttribute('capture')).toBe(false);
+  });
 });

--- a/src/components/ui/file-upload/file-upload.tsx
+++ b/src/components/ui/file-upload/file-upload.tsx
@@ -10,6 +10,10 @@ interface Props {
   error?: string;
   isMultiple?: boolean;
   accept?: string[];
+  // Sets the HTML `capture` attribute on the file input. `'environment'` prompts mobile browsers
+  // to open the rear camera, `'user'` the front camera. Ignored on desktop. See
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture
+  capture?: boolean | 'user' | 'environment';
   maxSizeMb?: number;
   onError?: (error: string) => void;
   translations?: {
@@ -26,6 +30,7 @@ const FileUpload: FC<Props> = ({
   onChange,
   isMultiple = false,
   accept = ['.jpg', '.jpeg', '.png', '.pdf', '.doc', '.docx', '.txt'],
+  capture,
   maxSizeMb = 2, // Default max size to 2MB
   onError = undefined,
   translations = {
@@ -118,6 +123,7 @@ const FileUpload: FC<Props> = ({
         ref={inputRef}
         multiple={isMultiple}
         accept={accept.join(',')}
+        capture={capture}
       />
       <div
         className={cn(


### PR DESCRIPTION
Adds an optional `capture` prop to `FileUpload`, forwarded to the underlying `<input type="file">` (see [MDN: capture](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture)).

- `capture="environment"` → mobile browsers open the rear camera; `"user"` → front camera. Ignored on desktop.
- Omitted by default, so existing behaviour is unchanged (snapshot test confirms the attribute is absent when not passed).

This lets consumers (ui-library, awell-next) offer direct camera capture for image upload questions instead of setting the attribute via a DOM ref workaround.

Version bumped to `0.16.6`.

Tests: 2 new specs (attribute set when provided / absent by default); `yarn build` (tsc + vite + tailwind) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)