### PR TITLE
feat(file-upload): add displayAccept to decouple label from input accept

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/design-system",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/ui/file-upload/file-upload.spec.tsx
+++ b/src/components/ui/file-upload/file-upload.spec.tsx
@@ -41,14 +41,20 @@ describe('FileList Component', () => {
     expect(input?.hasAttribute('capture')).toBe(false);
   });
 
-  it('keeps an "android/…" directive on the input accept but hides it from the label', () => {
+  it('defaults the supported-types label to accept when displayAccept is omitted', () => {
+    const { getByText } = subject({ accept: ['image/gif', 'image/jpg'] });
+    expect(getByText(/Supported file types:/).textContent).toContain('image/gif, image/jpg');
+  });
+
+  it('uses displayAccept for the label while the input keeps the full accept', () => {
     const { container, getByText } = subject({
       accept: ['image/gif', 'image/jpg', 'android/allowCamera'],
+      displayAccept: ['image/gif', 'image/jpg'],
     });
     const input = container.querySelector('input[type="file"]');
-    // The directive stays on the actual input attribute
+    // The full accept (incl. any marker) stays on the actual input attribute
     expect(input?.getAttribute('accept')).toBe('image/gif,image/jpg,android/allowCamera');
-    // …but is not shown in the helper text
+    // …but only displayAccept is shown in the helper text
     const label = getByText(/Supported file types:/).textContent;
     expect(label).toContain('image/gif, image/jpg');
     expect(label).not.toContain('android/allowCamera');

--- a/src/components/ui/file-upload/file-upload.tsx
+++ b/src/components/ui/file-upload/file-upload.tsx
@@ -9,7 +9,13 @@ interface Props {
   onChange: (files: FileList) => void;
   error?: string;
   isMultiple?: boolean;
+  // Values for the file input's `accept` attribute. Also used for the "Supported file types"
+  // label unless `displayAccept` is provided.
   accept?: string[];
+  // Optional override for the "Supported file types" label only (the input's `accept` still uses
+  // `accept`). Use this to hide non-file-type accept entries (e.g. platform markers) from the UI,
+  // or to show friendlier labels than raw MIME types. Falls back to `accept` when omitted.
+  displayAccept?: string[];
   // Sets the HTML `capture` attribute on the file input. `'environment'` prompts mobile browsers
   // to open the rear camera, `'user'` the front camera. Ignored on desktop. See
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture
@@ -30,6 +36,7 @@ const FileUpload: FC<Props> = ({
   onChange,
   isMultiple = false,
   accept = ['.jpg', '.jpeg', '.png', '.pdf', '.doc', '.docx', '.txt'],
+  displayAccept,
   capture,
   maxSizeMb = 2, // Default max size to 2MB
   onError = undefined,
@@ -113,16 +120,6 @@ const FileUpload: FC<Props> = ({
     setIsDragging(false);
   };
 
-  // `android/allowCamera` is a bogus (non-real) MIME type intentionally added to `accept`. On
-  // Android 14/15 the file input's camera option disappears unless `accept` contains a type the
-  // OS doesn't recognise as image/video/audio; adding this dummy type restores the "Camera" +
-  // file-picker options. It isn't a real file type, so hide it from the displayed list (it stays
-  // on the input's `accept`). See:
-  // https://blog.addpipe.com/html-file-input-accept-video-camera-option-is-missing-android-14-15/
-  const displayedFileTypes = accept
-    .filter((type) => !type.toLowerCase().startsWith('android/'))
-    .join(', ');
-
   return (
     <div className='flex flex-col gap-2'>
       {label && <label className='text-sm font-medium text-gray-700'>{label}</label>}
@@ -159,7 +156,7 @@ const FileUpload: FC<Props> = ({
         </Button>
         <div className='text-sm text-gray-500 text-center'>
           {translations.maxFileSize} {maxSizeMb}MB <br />
-          {translations.supportedFileTypes} {displayedFileTypes}
+          {translations.supportedFileTypes} {(displayAccept ?? accept).join(', ')}
         </div>
         <div
           className={cn(


### PR DESCRIPTION
Adds an optional `displayAccept?: string[]` prop to `FileUpload`:

- The **input's `accept`** attribute always uses `accept`.
- The **"Supported file types" label** uses `displayAccept` when provided, otherwise falls back to `accept`.

This decouples the label from the input so consumers can:
- hide non-file-type accept entries (e.g. an `android/allowCamera` marker) from the UI, and
- later show friendlier labels than raw MIME types.

`FileUpload` stays agnostic — it doesn't need to know what any accept entry means. Replaces the `android/`-specific label filter added in `0.16.8`.

Example: `accept={['image/gif','image/jpg','android/allowCamera']}` + `displayAccept={['image/gif','image/jpg']}` → input `accept="image/gif,image/jpg,android/allowCamera"`, label shows `image/gif, image/jpg`.

Version bump to `0.16.9`. Specs updated; `yarn build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)